### PR TITLE
IETF's Proof of Possession

### DIFF
--- a/scripts/build_spec.py
+++ b/scripts/build_spec.py
@@ -31,6 +31,7 @@ from eth2spec.utils.bls import (
     bls_aggregate_pubkeys,
     bls_verify,
     bls_verify_multiple,
+    bls_verify_pop,
     bls_sign,
 )
 
@@ -63,6 +64,7 @@ from eth2spec.utils.bls import (
     bls_aggregate_pubkeys,
     bls_verify,
     bls_verify_multiple,
+    bls_verify_pop,
     bls_signature_to_G2,
 )
 

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -380,7 +380,7 @@ class DepositData(Container):
     pubkey: BLSPubkey
     withdrawal_credentials: Hash
     amount: Gwei
-    signature: BLSSignature
+    proof_of_possession: BLSSignature
 ```
 
 #### `BeaconBlockHeader`
@@ -1655,9 +1655,9 @@ def process_deposit(state: BeaconState, deposit: Deposit) -> None:
     amount = deposit.data.amount
     validator_pubkeys = [v.pubkey for v in state.validators]
     if pubkey not in validator_pubkeys:
-        # Verify the deposit signature (proof of possession) for new validators.
+        # Verify the proof of possession for new validators.
         # Note: The deposit contract does not check signatures.
-        if not bls_verify_pop(pubkey, deposit.data.signature):
+        if not bls_verify_pop(pubkey, deposit.data.proof_of_possession):
             return
 
         # Add validator and balance entries

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -1658,9 +1658,7 @@ def process_deposit(state: BeaconState, deposit: Deposit) -> None:
     if pubkey not in validator_pubkeys:
         # Verify the deposit signature (proof of possession) for new validators.
         # Note: The deposit contract does not check signatures.
-        # Note: Deposits are valid across forks, thus the deposit domain is retrieved directly from `compute_domain`.
-        domain = compute_domain(DOMAIN_DEPOSIT)
-        if not bls_verify(pubkey, signing_root(deposit.data), deposit.data.signature, domain):
+        if not bls_verify_pop(pubkey, deposit.data.signature):
             return
 
         # Add validator and balance entries

--- a/specs/core/0_beacon-chain.md
+++ b/specs/core/0_beacon-chain.md
@@ -258,9 +258,8 @@ The following types are defined, mapping into `DomainType` (little endian):
 | `DOMAIN_BEACON_PROPOSER` | `0` |
 | `DOMAIN_RANDAO` | `1` |
 | `DOMAIN_ATTESTATION` | `2` |
-| `DOMAIN_DEPOSIT` | `3` |
-| `DOMAIN_VOLUNTARY_EXIT` | `4` |
-| `DOMAIN_TRANSFER` | `5` |
+| `DOMAIN_VOLUNTARY_EXIT` | `3` |
+| `DOMAIN_TRANSFER` | `4` |
 
 ## Containers
 

--- a/test_libs/pyspec/eth2spec/test/helpers/deposits.py
+++ b/test_libs/pyspec/eth2spec/test/helpers/deposits.py
@@ -31,7 +31,7 @@ def sign_deposit_data(spec, deposit_data, privkey, state=None):
         privkey=privkey,
         domain=domain,
     )
-    deposit_data.signature = signature
+    deposit_data.proof_of_possession = signature
 
 
 def build_deposit(spec,

--- a/test_libs/pyspec/eth2spec/utils/bls.py
+++ b/test_libs/pyspec/eth2spec/utils/bls.py
@@ -34,6 +34,12 @@ def bls_verify_multiple(pubkeys, message_hashes, signature, domain):
                                signature=signature, domain=domain)
 
 
+@only_with_bls(alt_return=True)
+def bls_verify_pop(pubkey, signature):
+    return bls.verify(message_hash=pubkey, pubkey=pubkey,
+                      signature=signature, domain=b'')
+
+
 @only_with_bls(alt_return=STUB_PUBKEY)
 def bls_aggregate_pubkeys(pubkeys):
     return bls.aggregate_pubkeys(pubkeys)


### PR DESCRIPTION
This is a proposal to switch to the IETF specs' proof-of-possession.

We currently use `sign(root(deposit_data))` whereas the IETF spec suggests using `sign(pubkey)`. I don't see a reason not to use the "official" PoP as the signature is only used to verify possession and not for security reasons.

Also please not that the ugliness of passing around the domain separation tag, `dst`, disappears when just using the PoP-ciphersuite defined by the IETF specs so in client codebases it should be cleaner.

@sigp, I apologise for using your repo, but I wanted to use @kirk-baird's branch for clean diffs.